### PR TITLE
EVG-12992: Standard benchmarking cannot run with go test

### DIFF
--- a/harness_suite.go
+++ b/harness_suite.go
@@ -92,7 +92,13 @@ func (s BenchmarkSuite) Run(ctx context.Context, prefix string) (BenchmarkResult
 func (s BenchmarkSuite) Standard(registry *RecorderRegistry) func(*testing.B) {
 	return func(b *testing.B) {
 		for _, test := range s {
-			b.Run(test.Name(), test.Standard(registry))
+			benchmark, closer := test.Standard(registry)
+			defer func() {
+				if err := closer(); err != nil {
+					b.Fatal(errors.Wrap(err, "benchmark cleanup"))
+				}
+			}()
+			b.Run(test.Name(), benchmark)
 		}
 	}
 }

--- a/harness_workload.go
+++ b/harness_workload.go
@@ -270,7 +270,13 @@ func (w *BenchmarkWorkload) Standard(registry *RecorderRegistry) func(*testing.B
 				}()
 
 				if w.Case != nil {
-					b.Run(fmt.Sprintf("WorkloadCase%s%s#%d", w.WorkloadName, w.Case.Name(), id), w.Case.Standard(registry))
+					benchmark, closer := w.Case.Standard(registry)
+					defer func() {
+						if err := closer(); err != nil {
+							b.Fatal(errors.Wrap(err, "benchmark cleanup"))
+						}
+					}()
+					b.Run(fmt.Sprintf("WorkloadCase%s%s#%d", w.WorkloadName, w.Case.Name(), id), benchmark)
 					return
 				}
 

--- a/registry.go
+++ b/registry.go
@@ -243,7 +243,7 @@ func (r *RecorderRegistry) SetBenchRecorderPrefix(prefix string) {
 // MakeBenchmark configures a recorder to support executing a
 // BenchmarkCase in the form of a standard library benchmarking
 // format.
-func (r *RecorderRegistry) MakeBenchmark(bench *BenchmarkCase) func(*testing.B) {
+func (r *RecorderRegistry) MakeBenchmark(bench *BenchmarkCase) (func(*testing.B), func() error) {
 	name := bench.Name()
 	r.mu.Lock()
 	fqname := filepath.Join(r.benchPrefix, name) + ".ftdc"
@@ -258,10 +258,11 @@ func (r *RecorderRegistry) MakeBenchmark(bench *BenchmarkCase) func(*testing.B) 
 	})
 
 	if err != nil {
-		return func(b *testing.B) { b.Fatal(errors.Wrap(err, "problem making recorder")) }
+		return func(b *testing.B) { b.Fatal(errors.Wrap(err, "problem making recorder")) },
+			func() error { return nil }
 	}
 
-	return bench.Bench.standard(recorder, func() error { return r.Close(name) })
+	return bench.Bench.standard(recorder), func() error { return r.Close(name) }
 }
 
 // Close flushes and closes the underlying recorder and collector and


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-12992

- Call the closer method in the suite standard benchmark instead of the case standard benchmark.
- Add a simple benchmark to the tests.