### PR TITLE
EVG-12866: Add the ability to read a subset of a Report

### DIFF
--- a/report_read.go
+++ b/report_read.go
@@ -28,9 +28,9 @@ func getUnmarshaler(fn string) unmarshaler {
 
 // LoadReport reads the content of the specified file and attempts to create a
 // Report structure based on the content. The file can be in bson, json, or
-// yaml, and LoadReport examines the files' extension to determine the data
+// yaml, and LoadReport examines the file's extension to determine the data
 // format. If the bucket API key, secret, or token are not populated, the
-// corresponding environment variables will be used to populated the values.
+// corresponding environment variables will be used to populate the values.
 func LoadReport(fn string) (*Report, error) {
 	out := &Report{}
 	if err := readFile(fn, out); err != nil {
@@ -52,10 +52,10 @@ func LoadReport(fn string) (*Report, error) {
 
 // LoadTests reads the content of the specified file and attempts to create a
 // Report structure based on the content. The file can be in json or yaml and
-// LoadTests examines the files' extension to determine the data format. Note
+// LoadTests examines the file's extension to determine the data format. Note
 // that this expects a subset of the actual Report data, as an array of Test
-// objects, and will return a Report object with empty fields except for the
-// `Tests` field.
+// structures, and will return a Report instance with empty fields except for
+// the `Tests` field.
 func LoadTests(fn string) (*Report, error) {
 	if strings.HasSuffix(fn, ".bson") {
 		return nil, errors.New("cannot load an array of tests from bson")

--- a/report_read.go
+++ b/report_read.go
@@ -26,30 +26,15 @@ func getUnmarshaler(fn string) unmarshaler {
 	}
 }
 
-// LoadReport reads the content of the specified file and attempts to
-// create a Report structure based on the content. The file can be in
-// bson, json, or yaml, and LoadReport examines the files' extension
-// to determine the data format. If the bucket API key, secret, or token are
-// not populated, the corresponding environment variables will be used to
-// populated the values.
+// LoadReport reads the content of the specified file and attempts to create a
+// Report structure based on the content. The file can be in bson, json, or
+// yaml, and LoadReport examines the files' extension to determine the data
+// format. If the bucket API key, secret, or token are not populated, the
+// corresponding environment variables will be used to populated the values.
 func LoadReport(fn string) (*Report, error) {
-	if stat, err := os.Stat(fn); os.IsNotExist(err) || stat.IsDir() {
-		return nil, errors.Errorf("'%s' does not exist", fn)
-	}
-
-	unmarshal := getUnmarshaler(fn)
-	if unmarshal == nil {
-		return nil, errors.Errorf("cannot find unmarshler for input %s", fn)
-	}
-
-	data, err := ioutil.ReadFile(fn)
-	if err != nil {
-		return nil, errors.Wrapf(err, "problem reading data from %s", fn)
-	}
-
-	out := Report{}
-	if err = unmarshal(data, &out); err != nil {
-		return nil, errors.Wrap(err, "problem unmarshaling report data")
+	out := &Report{}
+	if err := readFile(fn, out); err != nil {
+		return nil, err
 	}
 
 	if out.BucketConf.APIKey == "" {
@@ -62,5 +47,44 @@ func LoadReport(fn string) (*Report, error) {
 		out.BucketConf.APIToken = os.Getenv(APITokenEnv)
 	}
 
-	return &out, nil
+	return out, nil
+}
+
+// LoadTests reads the content of the specified file and attempts to create a
+// Report structure based on the content. The file can be in json or yaml and
+// LoadTests examines the files' extension to determine the data format. Note
+// that this expects a subset of the actual Report data, as an array of Test
+// objects, and will return a Report object with empty fields except for the
+// `Tests` field.
+func LoadTests(fn string) (*Report, error) {
+	if strings.HasSuffix(fn, ".bson") {
+		return nil, errors.New("cannot load an array of tests from bson")
+	}
+
+	out := []Test{}
+	if err := readFile(fn, &out); err != nil {
+		return nil, err
+	}
+
+	report := &Report{}
+	report.Tests = out
+	return report, nil
+}
+
+func readFile(fn string, out interface{}) error {
+	if stat, err := os.Stat(fn); os.IsNotExist(err) || stat.IsDir() {
+		return errors.Errorf("'%s' does not exist", fn)
+	}
+
+	unmarshal := getUnmarshaler(fn)
+	if unmarshal == nil {
+		return errors.Errorf("cannot find unmarshler for input %s", fn)
+	}
+
+	data, err := ioutil.ReadFile(fn)
+	if err != nil {
+		return errors.Wrapf(err, "problem reading data from %s", fn)
+	}
+
+	return errors.Wrap(unmarshal(data, out), "problem unmarshaling report data")
 }

--- a/report_read_test.go
+++ b/report_read_test.go
@@ -71,3 +71,57 @@ func TestLoadReport(t *testing.T) {
 		})
 	}
 }
+
+func TestLoadTests(t *testing.T) {
+	data, err := ioutil.ReadFile("testdata/tests.json")
+	require.NoError(t, err)
+	expectedTests := []Test{}
+	require.NoError(t, json.Unmarshal(data, &expectedTests))
+	expectedReport := &Report{Tests: expectedTests}
+
+	for _, test := range []struct {
+		name   string
+		fn     string
+		hasErr bool
+	}{
+		{
+			name:   "FileDoesNotExist",
+			fn:     "DNE",
+			hasErr: true,
+		},
+		{
+			name:   "FileIsDir",
+			fn:     "testdata",
+			hasErr: true,
+		},
+		{
+			name:   "NoUnmarshaler",
+			fn:     "testdata/csv_example.csv",
+			hasErr: true,
+		},
+		{
+			name:   "MarshalsBSONFails",
+			fn:     "testdata/report.bson",
+			hasErr: true,
+		},
+		{
+			name: "MarshalsJSONCorrectly",
+			fn:   "testdata/tests.json",
+		},
+		{
+			name: "MarshalsYAMLCorrectly",
+			fn:   "testdata/tests.yaml",
+		},
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			report, err := LoadTests(test.fn)
+			if test.hasErr {
+				assert.Nil(t, report)
+				assert.Error(t, err)
+			} else {
+				assert.Equal(t, expectedReport, report)
+				assert.NoError(t, err)
+			}
+		})
+	}
+}

--- a/testdata/tests.json
+++ b/testdata/tests.json
@@ -1,0 +1,12 @@
+[
+    {
+        "info": {
+            "test_name": "test1"
+        }
+    },
+    {
+        "info": {
+            "test_name": "test2"
+        }
+    }
+]

--- a/testdata/tests.yaml
+++ b/testdata/tests.yaml
@@ -1,0 +1,4 @@
+- info:
+    test_name: test1
+- info:
+    test_name: test2


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-12866

This a part of a ticket to add a new evg command that sends perf data directly to cedar. The users will not be expected to have the necessary evergreen data to generate the report and will only send an array of test results in either a json or bson file.

- add a function `LoadTests` that loads an array of `Test` structures and returns a `Report` empty fields except for the `Test` field.