### PR TITLE
[nomerge] [POC] EVG-13260 Allow for server-side buffering in Poplar

### DIFF
--- a/rpc/internal/collector.service.go
+++ b/rpc/internal/collector.service.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"io"
 	"sync"
-    //"fmt"
+	//"fmt"
 
 	"github.com/evergreen-ci/poplar"
 	"github.com/evergreen-ci/utility"
@@ -106,8 +106,8 @@ func (s *collectorService) StreamEvents(srv PoplarEventCollector_StreamEventsSer
 			return status.Errorf(codes.InvalidArgument, "cannot request different registries in the same stream")
 		}
 
-        group.appendEvent(streamID, event.Export())
-        group.processBuffers()
+		group.appendEvent(streamID, event.Export())
+		group.processBuffers()
 
 		if ctx.Err() != nil {
 			return status.Errorf(codes.Canceled, "operation canceled for %s", eventName)
@@ -132,7 +132,7 @@ type streamGroup struct {
 	collector        events.Collector
 	availableStreams []string
 	streams          map[string]chan error
-    buffers          map[string][]*events.Performance 
+	buffers          map[string][]*events.Performance
 	eventHeap        *PerformanceHeap
 	mu               sync.Mutex
 }
@@ -155,7 +155,7 @@ func (sc *streamsCoordinator) addStream(name string, registry *poplar.RecorderRe
 			collector:        collector,
 			availableStreams: []string{},
 			streams:          map[string]chan error{},
-            buffers:          make(map[string][]*events.Performance),
+			buffers:          make(map[string][]*events.Performance),
 			eventHeap:        &PerformanceHeap{},
 		}
 		heap.Init(group.eventHeap)
@@ -168,7 +168,7 @@ func (sc *streamsCoordinator) addStream(name string, registry *poplar.RecorderRe
 	id := utility.RandomString()
 	group.streams[id] = make(chan error)
 	group.buffers[id] = make([]*events.Performance, 0)
-    group.availableStreams = append(group.availableStreams, id)
+	group.availableStreams = append(group.availableStreams, id)
 
 	return nil
 }
@@ -193,12 +193,11 @@ func (sc *streamsCoordinator) getStream(name string) (string, *streamGroup, erro
 	return id, group, nil
 }
 
-
 func (sg *streamGroup) appendEvent(id string, event *events.Performance) {
-    sg.mu.Lock()
-    defer sg.mu.Unlock()
+	sg.mu.Lock()
+	defer sg.mu.Unlock()
 
-    sg.buffers[id] = append(sg.buffers[id], event)
+	sg.buffers[id] = append(sg.buffers[id], event)
 
 }
 
@@ -206,24 +205,24 @@ func (sg *streamGroup) processBuffers() {
 	sg.mu.Lock()
 	defer sg.mu.Unlock()
 
-    // We process until there's a buffer that's not ready to pop.
-    for true {
+	// We process until there's a buffer that's not ready to pop.
+	for true {
 
-        var min = ""
-        // Only proceed if each buffer has a processable element.
-        for id, buffer := range sg.buffers {
-            if len(buffer) == 0 {
-                return
-            }
-            if min == "" || buffer[0].Timestamp.Before(sg.buffers[min][0].Timestamp) {
-                min = id
-            }
-        }
+		var min = ""
+		// Only proceed if each buffer has a processable element.
+		for id, buffer := range sg.buffers {
+			if len(buffer) == 0 {
+				return
+			}
+			if min == "" || buffer[0].Timestamp.Before(sg.buffers[min][0].Timestamp) {
+				min = id
+			}
+		}
 
-        // fmt.Println("Actually writing event.")
-        sg.collector.AddEvent(sg.buffers[min][0])
-        sg.buffers[min] = sg.buffers[min][1:]
-    }
+		// fmt.Println("Actually writing event.")
+		sg.collector.AddEvent(sg.buffers[min][0])
+		sg.buffers[min] = sg.buffers[min][1:]
+	}
 
 }
 
@@ -265,8 +264,8 @@ func (sg *streamGroup) sendError(item *performanceHeapItem) {
 // underlying min heap is full, it will pop the heap and write the item to the
 // collector.
 func (sg *streamGroup) removeStream(id string) {
-    sg.processBuffers()
-    
+	sg.processBuffers()
+
 	sg.mu.Lock()
 	defer sg.mu.Unlock()
 

--- a/rpc/internal/collector.service.go
+++ b/rpc/internal/collector.service.go
@@ -5,7 +5,6 @@ import (
 	"context"
 	"io"
 	"sync"
-	//"fmt"
 
 	"github.com/evergreen-ci/poplar"
 	"github.com/evergreen-ci/utility"
@@ -219,7 +218,6 @@ func (sg *streamGroup) processBuffers() {
 			}
 		}
 
-		// fmt.Println("Actually writing event.")
 		sg.collector.AddEvent(sg.buffers[min][0])
 		sg.buffers[min] = sg.buffers[min][1:]
 	}


### PR DESCRIPTION
I don't know Go so this is probably super messy, and I didn't know how to make it work with the error channels, but it seemed to have the semantics we want when I ran it locally and checked the outputs.

The important things are that this allows stream A to send 100 events while stream B hasn't sent any, and stream A can finish with the assumption that those buffered events will be taken care of when stream B starts.

I couldn't figure out how to integrate with the minheap cleanly, but I think the current solution of calling `processBuffers` so often is bad because it holds the lock and can block appends from other streams. Maybe integration with the minheap would help with that? Or maybe `processBuffers` could be called a fraction of the time?

Patch that collected valid data at high throughput: https://evergreen.mongodb.com/version/5f8f3f8e3066151950feeeba