### PR TITLE
EVG-13260: Allow for server-side buffering in Poplar

### DIFF
--- a/rpc/internal/collector.service.go
+++ b/rpc/internal/collector.service.go
@@ -79,10 +79,11 @@ func (s *collectorService) StreamEvents(srv PoplarEventCollector_StreamEventsSer
 	for {
 		event, err := srv.Recv()
 		if err == io.EOF {
-			if err = group.closeStream(streamID); err != nil {
-				return status.Errorf(codes.Internal, "problem persisting argument %s", err.Error())
+			if group != nil {
+				if err = group.closeStream(streamID); err != nil {
+					return status.Errorf(codes.Internal, "problem persisting argument %s", err.Error())
+				}
 			}
-
 			return srv.SendAndClose(&PoplarResponse{
 				Name:   eventName,
 				Status: true,

--- a/rpc/internal/collector.service.go
+++ b/rpc/internal/collector.service.go
@@ -232,14 +232,6 @@ func (sg *streamGroup) addEvent(ctx context.Context, id string, event *events.Pe
 			return errors.Wrap(ctx.Err(), "context canceled while waiting on buffer")
 		}
 	}
-
-	var e *events.Performance
-	select {
-	case e = <-stream.buffer:
-		stream.buffer <- e
-	default:
-		e = event
-	}
 	sg.eventHeap.SafePush(&performanceHeapItem{id: id, event: event})
 	stream.inHeap = true
 

--- a/rpc/internal/collector.service.go
+++ b/rpc/internal/collector.service.go
@@ -143,7 +143,6 @@ type streamGroup struct {
 type stream struct {
 	inHeap bool
 	closed bool
-	next   *events.Performance
 	buffer chan *events.Performance
 }
 

--- a/rpc/internal/collector.service.go
+++ b/rpc/internal/collector.service.go
@@ -205,9 +205,9 @@ func (sc *streamsCoordinator) getStream(name string) (string, *streamGroup, erro
 	return id, group, nil
 }
 
-// addEvent writes the given event to the stream buffer. It also attempts to
-// write an item to the collector from the min heap. If the stream does not
-// exist or is already closed an error is returned.
+// addEvent writes the given event to the stream's buffer. If the time since
+// the last flush has surpassed the flush interval, the flush method is called.
+// If the stream does not exist or is already closed an error is returned.
 func (sg *streamGroup) addEvent(ctx context.Context, id string, event *events.Performance) error {
 	sg.mu.Lock()
 	defer sg.mu.Unlock()

--- a/rpc/internal/collector.service.go
+++ b/rpc/internal/collector.service.go
@@ -225,8 +225,12 @@ func (sg *streamGroup) addEvent(ctx context.Context, id string, event *events.Pe
 	}
 
 	if stream.inHeap {
-		stream.buffer <- event
-		return nil
+		select {
+		case stream.buffer <- event:
+			return nil
+		case <-ctx.Done():
+			return errors.Wrap(ctx.Err(), "context canceled while waiting on buffer")
+		}
 	}
 
 	var e *events.Performance

--- a/rpc/internal/collector.service.go
+++ b/rpc/internal/collector.service.go
@@ -253,7 +253,7 @@ func (sg *streamGroup) closeStream(id string) error {
 	return errors.Wrap(sg.flush(), "problem flushing to collector")
 }
 
-// flush attemps to flush all the streams' buffers to the collector. Each time
+// flush attempts to flush all the streams' buffers to the collector. Each time
 // an event is flushed, the next event from the corresponding stream is added
 // to the min heap. This stops flushing once there are less events in the heap
 // than streams in the group. Note that this function is not thread safe.
@@ -279,7 +279,7 @@ func (sg *streamGroup) flush() error {
 				sg.eventHeap.SafePush(&performanceHeapItem{id: item.id, event: event})
 				stream.inHeap = true
 			default:
-				// Do nothing, buffer emtpy.
+				// Do nothing, buffer empty.
 			}
 
 		}

--- a/rpc/internal/collector.service.go
+++ b/rpc/internal/collector.service.go
@@ -226,8 +226,8 @@ func (sg *streamGroup) addEvent(ctx context.Context, id string, event *events.Pe
 		select {
 		case stream.buffer <- event:
 			return nil
-		case <-ctx.Done():
-			return errors.Wrap(ctx.Err(), "context canceled while waiting on buffer")
+		default:
+			return errors.New("event buffer full for this stream")
 		}
 	}
 	sg.eventHeap.SafePush(&performanceHeapItem{id: id, event: event})

--- a/rpc/internal/collector.service.go
+++ b/rpc/internal/collector.service.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"io"
 	"sync"
+	"time"
 
 	"github.com/evergreen-ci/poplar"
 	"github.com/evergreen-ci/utility"
@@ -98,7 +99,7 @@ func (s *collectorService) StreamEvents(srv PoplarEventCollector_StreamEventsSer
 			if err != nil {
 				return status.Error(codes.FailedPrecondition, errors.Wrap(err, "failed to get stream").Error())
 			}
-			defer group.removeStream(streamID)
+			defer group.closeStream(streamID)
 		}
 
 		if event.Name != eventName {
@@ -131,9 +132,19 @@ type streamsCoordinator struct {
 type streamGroup struct {
 	collector        events.Collector
 	availableStreams []string
-	streams          map[string]chan error
+	streams          map[string]*stream
 	eventHeap        *PerformanceHeap
+	lastFlush        time.Time
+	catcher          grip.Catcher
 	mu               sync.Mutex
+}
+
+// stream represents a single stream in a stream group.
+type stream struct {
+	inHeap bool
+	closed bool
+	next   *events.Performance
+	buffer chan *events.Performance
 }
 
 // addStream adds a new stream to the group for the given collector. If the
@@ -153,8 +164,10 @@ func (sc *streamsCoordinator) addStream(name string, registry *poplar.RecorderRe
 		group = &streamGroup{
 			collector:        collector,
 			availableStreams: []string{},
-			streams:          map[string]chan error{},
+			streams:          map[string]*stream{},
 			eventHeap:        &PerformanceHeap{},
+			lastFlush:        time.Now(),
+			catcher:          grip.NewBasicCatcher(),
 		}
 		heap.Init(group.eventHeap)
 		sc.groups[name] = group
@@ -164,7 +177,7 @@ func (sc *streamsCoordinator) addStream(name string, registry *poplar.RecorderRe
 	defer group.mu.Unlock()
 
 	id := utility.RandomString()
-	group.streams[id] = make(chan error)
+	group.streams[id] = &stream{buffer: make(chan *events.Performance, 1000)} // TODO: figure out good buffer size
 	group.availableStreams = append(group.availableStreams, id)
 
 	return nil
@@ -181,6 +194,9 @@ func (sc *streamsCoordinator) getStream(name string) (string, *streamGroup, erro
 		return "", nil, errors.Errorf("no group for '%s'", name)
 	}
 
+	group.mu.Lock()
+	defer group.mu.Unlock()
+
 	if len(group.availableStreams) == 0 {
 		return "", nil, errors.New("must register first")
 	}
@@ -190,54 +206,107 @@ func (sc *streamsCoordinator) getStream(name string) (string, *streamGroup, erro
 	return id, group, nil
 }
 
-// addEvent writes the given event to the collector from the given stream. If
-// the stream does not exist an error is returned. Note that this function
-// blocks until all streams in the group have an entry in the heap, at which
-// point the timestamp can be guaranteed.
+// addEvent writes the given event to the stream buffer. It also attempts to
+// write an item to the collector from the min heap. If the stream does not
+// exist or is already closed an error is returned.
 func (sg *streamGroup) addEvent(ctx context.Context, id string, event *events.Performance) error {
-	sg.mu.Lock()
-
-	errChan, ok := sg.streams[id]
-	if !ok {
-		sg.mu.Unlock()
-		return errors.Errorf("stream %s does not exist in this stream group", id)
-	}
-
-	sg.eventHeap.SafePush(&performanceHeapItem{errChan: errChan, event: event})
-	if sg.eventHeap.Len() >= len(sg.streams) {
-		item := sg.eventHeap.SafePop()
-		go sg.sendError(item)
-	}
-
-	sg.mu.Unlock()
-	select {
-	case <-ctx.Done():
-		return errors.Wrap(ctx.Err(), "context canceled while adding event")
-	case err := <-errChan:
-		return err
-	}
-}
-
-// sendError writes the next item from the heap to the collector and sends the
-// error, if any, to the corresponding error channel.
-func (sg *streamGroup) sendError(item *performanceHeapItem) {
-	if item != nil {
-		item.errChan <- sg.collector.AddEvent(item.event)
-	}
-}
-
-// removeStream removes the given stream from the stream group. If the
-// underlying min heap is full, it will pop the heap and write the item to the
-// collector.
-func (sg *streamGroup) removeStream(id string) {
 	sg.mu.Lock()
 	defer sg.mu.Unlock()
 
-	delete(sg.streams, id)
-	if sg.eventHeap.Len() >= len(sg.streams) {
-		item := sg.eventHeap.SafePop()
-		go sg.sendError(item)
+	if sg.catcher.HasErrors() {
+		return sg.catcher.Resolve()
 	}
+
+	stream, ok := sg.streams[id]
+	if !ok {
+		return errors.Errorf("stream '%s' does not exist in this stream group", id)
+	}
+	if stream.closed {
+		return errors.Errorf("stream '%s' already closed", id)
+	}
+
+	if stream.inHeap {
+		stream.buffer <- event
+		return nil
+	}
+
+	var e *events.Performance
+	select {
+	case e = <-stream.buffer:
+		stream.buffer <- e
+	default:
+		e = event
+	}
+	sg.eventHeap.SafePush(&performanceHeapItem{id: id, event: event})
+	stream.inHeap = true
+
+	if time.Since(sg.lastFlush) > 5*time.Second { // TODO: figure out a good flush interval
+		return errors.Wrap(sg.flush(), "problem persisting data")
+	}
+
+	return nil
+}
+
+// closeStream marks the given stream as closed. Once all the items in the
+// stream's buffer have been written to the collector, the stream will be
+// removed from the stream.
+func (sg *streamGroup) closeStream(id string) {
+	sg.mu.Lock()
+	defer sg.mu.Unlock()
+
+	stream, ok := sg.streams[id]
+	if !ok {
+		return
+	}
+	stream.closed = true
+	if len(stream.buffer) == 0 {
+		delete(sg.streams, id)
+	}
+
+	sg.catcher.Add(errors.Wrap(sg.flush(), "problem persisting data"))
+}
+
+// flush attemps to flush all the streams' buffers to the collector. Each time
+// an event is flushed, the next event from the corresponding stream is added
+// to the min heap. This stops flushing once there are less events in the heap
+// than streams in the group. Note that this function is not thread safe.
+func (sg *streamGroup) flush() error {
+	defer func() {
+		sg.lastFlush = time.Now()
+	}()
+
+	for sg.eventHeap.Len() >= len(sg.streams) {
+		item := sg.eventHeap.SafePop()
+		if item == nil {
+			break
+		}
+
+		stream, ok := sg.streams[item.id]
+		if ok {
+			if stream.closed && len(stream.buffer) == 0 {
+				// Remove closed stream with empty buffer.
+				delete(sg.streams, item.id)
+			} else {
+				stream.inHeap = false
+			}
+			select {
+			case event := <-stream.buffer:
+				// Get next event from stream's buffer and add
+				// it to the min heap.
+				sg.eventHeap.SafePush(&performanceHeapItem{id: item.id, event: event})
+				stream.inHeap = true
+			default:
+				// Do nothing, buffer emtpy.
+			}
+
+		}
+
+		if err := sg.collector.AddEvent(item.event); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // PerformanceHeap is a min heap of ftdc/events.Performance objects.
@@ -246,8 +315,8 @@ type PerformanceHeap struct {
 }
 
 type performanceHeapItem struct {
-	errChan chan error
-	event   *events.Performance
+	id    string
+	event *events.Performance
 }
 
 // Len returns the size of the heap.

--- a/rpc/internal/collector.service_test.go
+++ b/rpc/internal/collector.service_test.go
@@ -28,7 +28,7 @@ func TestCreateCollector(t *testing.T) {
 	defer func() {
 		assert.NoError(t, os.RemoveAll(tmpDir))
 	}()
-	svc := getTestCollectorService(tmpDir)
+	svc := getTestCollectorService(t, tmpDir)
 	defer func() {
 		assert.NoError(t, closeCollectorService(svc))
 	}()
@@ -88,7 +88,7 @@ func TestCloseCollector(t *testing.T) {
 	defer func() {
 		assert.NoError(t, os.RemoveAll(tmpDir))
 	}()
-	svc := getTestCollectorService(tmpDir)
+	svc := getTestCollectorService(t, tmpDir)
 	defer func() {
 		assert.NoError(t, closeCollectorService(svc))
 	}()
@@ -125,7 +125,7 @@ func TestSendEvent(t *testing.T) {
 	defer func() {
 		assert.NoError(t, os.RemoveAll(tmpDir))
 	}()
-	svc := getTestCollectorService(tmpDir)
+	svc := getTestCollectorService(t, tmpDir)
 	defer func() {
 		assert.NoError(t, closeCollectorService(svc))
 	}()
@@ -173,7 +173,7 @@ func TestRegisterStream(t *testing.T) {
 	defer func() {
 		assert.NoError(t, os.RemoveAll(tmpDir))
 	}()
-	svc := getTestCollectorService(tmpDir)
+	svc := getTestCollectorService(t, tmpDir)
 	defer func() {
 		assert.NoError(t, closeCollectorService(svc))
 	}()
@@ -226,7 +226,7 @@ func TestStreamEvent(t *testing.T) {
 	defer func() {
 		assert.NoError(t, os.RemoveAll(tmpDir))
 	}()
-	svc := getTestCollectorService(tmpDir)
+	svc := getTestCollectorService(t, tmpDir)
 	defer func() {
 		assert.NoError(t, closeCollectorService(svc))
 	}()
@@ -402,22 +402,24 @@ func TestStreamEvent(t *testing.T) {
 	})
 }
 
-func getTestCollectorService(tmpDir string) *collectorService {
+func getTestCollectorService(t *testing.T, tmpDir string) *collectorService {
 	registry := poplar.NewRegistry()
-	registry.Create("collector", poplar.CreateOptions{
+	_, err := registry.Create("collector", poplar.CreateOptions{
 		Path:      filepath.Join(tmpDir, "exists"),
 		ChunkSize: 5,
 		Recorder:  poplar.RecorderPerf,
 		Dynamic:   true,
 		Events:    poplar.EventsCollectorBasic,
 	})
-	registry.Create("multiple", poplar.CreateOptions{
+	require.NoError(t, err)
+	_, err = registry.Create("multiple", poplar.CreateOptions{
 		Path:      filepath.Join(tmpDir, "multiple"),
 		ChunkSize: 5,
 		Recorder:  poplar.RecorderPerf,
 		Dynamic:   true,
 		Events:    poplar.EventsCollectorBasic,
 	})
+	require.NoError(t, err)
 
 	return &collectorService{
 		registry: registry,


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-13260

This ticket enables server side buffer for the gRPC collector service:
- Add a new type struct `stream` to the service code which holds the a stream's buffer and other information.
- Add a flush method to the `streamGroup` type struct.
- Call `flush` in `streamGroup.addEvent` if last flush was more than 5 seconds ago.
- Call `flush` in `streamGroup.closeStream`.

There are two outstanding TODOs:
1. Determine a reasonable buffer size for each stream.
2. Determine a reasonable flush interval.