### PR TITLE
EVG-13779: Close streams when collector is closed

### DIFF
--- a/rpc/internal/collector.service.go
+++ b/rpc/internal/collector.service.go
@@ -34,14 +34,22 @@ func (s *collectorService) CreateCollector(ctx context.Context, opts *CreateOpti
 }
 
 func (s *collectorService) CloseCollector(ctx context.Context, id *PoplarID) (*PoplarResponse, error) {
-	err := s.registry.Close(id.Name)
+	catcher := grip.NewBasicCatcher()
 
-	grip.Error(message.WrapError(err, message.Fields{
+	for _, group := range s.coordinator.groups {
+		for streamID, _ := range group.streams {
+			catcher.Add(group.closeStream(streamID))
+
+		}
+	}
+	catcher.Add(s.registry.Close(id.Name))
+
+	grip.Error(message.WrapError(catcher.Resolve(), message.Fields{
 		"message":  "problem closing recorder",
 		"recorder": id.Name,
 	}))
 
-	return &PoplarResponse{Name: id.Name, Status: err == nil}, nil
+	return &PoplarResponse{Name: id.Name, Status: !catcher.HasErrors()}, nil
 }
 
 func (s *collectorService) SendEvent(ctx context.Context, event *EventMetrics) (*PoplarResponse, error) {

--- a/rpc/internal/collector.service.go
+++ b/rpc/internal/collector.service.go
@@ -37,9 +37,8 @@ func (s *collectorService) CloseCollector(ctx context.Context, id *PoplarID) (*P
 	catcher := grip.NewBasicCatcher()
 
 	for _, group := range s.coordinator.groups {
-		for streamID, _ := range group.streams {
+		for streamID := range group.streams {
 			catcher.Add(group.closeStream(streamID))
-
 		}
 	}
 	catcher.Add(s.registry.Close(id.Name))


### PR DESCRIPTION
Ticket: https://jira.mongodb.org/browse/EVG-13779

This PR simply closes all open streams when a collector is closed.