### PR TITLE
EVG-15682: remove DISABLE_COVERAGE flag

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -39,8 +39,8 @@ All project automation is managed by a makefile, with all output captured in the
    make lint                    # lints all packages
    make test-<package>          # runs the tests only for a specific packages
    make lint-<package>          # lints a specific package
-   make html-coverage-<package> # generates the coverage report for a specific package
-   make coverage-html           # generates the coverage report for all packages
+   make html-coverage-<package> # generates the HTML coverage report for a specific package
+   make html-coverage           # generates the HTML coverage report for all packages
 
 The buildsystem also has a number of flags, which may be useful for more
 iterative development workflows: ::

--- a/evergreen.yaml
+++ b/evergreen.yaml
@@ -38,7 +38,7 @@ functions:
       working_dir: poplar
       binary: make
       args: ["${target}"]
-      include_expansions_in_env: ["DISABLE_COVERAGE", "GOROOT", "RACE_DETECTOR"]
+      include_expansions_in_env: ["GOROOT", "RACE_DETECTOR"]
       env:
         AWS_ACCESS_KEY_ID: ${aws_key}
         AWS_SECRET_ACCESS_KEY: ${aws_secret}
@@ -120,7 +120,6 @@ buildvariants:
   - name: race-detector
     display_name: Race Detector (Arch Linux)
     expansions:
-      DISABLE_COVERAGE: true
       GOROOT: /opt/golang/go1.16
       RACE_DETECTOR: true
     run_on:
@@ -132,7 +131,6 @@ buildvariants:
   - name: lint
     display_name: Lint (Arch Linux)
     expansions:
-      DISABLE_COVERAGE: true
       GOROOT: /opt/golang/go1.16
     run_on:
       - archlinux-new-small
@@ -143,7 +141,6 @@ buildvariants:
   - name: ubuntu
     display_name: Ubuntu 18.04
     expansions:
-      DISABLE_COVERAGE: true
       GOROOT: /opt/golang/go1.16
     run_on:
       - ubuntu1804-small
@@ -154,7 +151,6 @@ buildvariants:
   - name: macos
     display_name: macOS 10.14
     expansions:
-      DISABLE_COVERAGE: true
       GOROOT: /opt/golang/go1.16
     run_on:
       - macos-1014
@@ -170,6 +166,5 @@ buildvariants:
       - windows-64-vs2017-large
     expansions:
       GOROOT: C:/golang/go1.16
-      DISABLE_COVERAGE: true
     tasks:
       - name: ".test"

--- a/evergreen.yaml
+++ b/evergreen.yaml
@@ -99,7 +99,7 @@ tasks:
         vars: { target: "${task_name}" }
 
   - <<: *run-build
-    name: coverage-html
+    name: html-coverage
     tags: ["report"]
 
   - <<: *run-build

--- a/makefile
+++ b/makefile
@@ -62,10 +62,10 @@ $(buildDir)/run-linter:cmd/run-linter/run-linter.go $(buildDir)/golangci-lint
 
 # start output files
 coverageOutput := $(foreach target,$(packages),$(buildDir)/output.$(target).coverage)
-coverageHtmlOutput := $(foreach target,$(packages),$(buildDir)/output.$(target).coverage.html)
+htmlCoverageOutput := $(foreach target,$(packages),$(buildDir)/output.$(target).coverage.html)
 lintOutput := $(foreach target,$(packages),$(buildDir)/output.$(target).lint)
 testOutput := $(foreach target,$(packages),$(buildDir)/output.$(target).test)
-.PRECIOUS:$(coverageOutput) $(coverageHtmlOutput) $(lintOutput) $(testOutput)
+.PRECIOUS:$(coverageOutput) $(htmlCoverageOutput) $(lintOutput) $(testOutput)
 # end output files
 
 # start basic development operations
@@ -76,7 +76,7 @@ benchPattern := ./
 benchmark:
 	$(gobin) test $(testArgs) -bench=$(benchPattern) $(if $(RUN_TEST),, -run=^^$$) | tee $(buildDir)/bench.out
 coverage: $(coverageOutput)
-coverage-html: $(coverageHtmlOutput)
+html-coverage: $(htmlCoverageOutput)
 lint: $(lintOutput)
 # TODO (EVG-15699): figure out how to make this tooling work without using a vendor directory.
 proto:
@@ -85,7 +85,7 @@ proto:
 	protoc --go_out=plugins=grpc:rpc/internal vendor/cedar.proto
 	protoc --go_out=plugins=grpc:collector *.proto
 	mv rpc/internal/vendor/cedar.pb.go rpc/internal/cedar.pb.go
-phony += compile lint test coverage coverage-html proto
+phony += compile lint test coverage html-coverage proto
 
 # start convenience targets for running tests and coverage tasks on a
 # specific package.

--- a/makefile
+++ b/makefile
@@ -102,9 +102,6 @@ lint-%: $(buildDir)/output.%.lint
 
 # start test and coverage artifacts
 testArgs := -v
-ifeq (,$(DISABLE_COVERAGE))
-testArgs += -cover
-endif
 ifneq (,$(RACE_DETECTOR))
 testArgs += -race
 endif


### PR DESCRIPTION
Jira: https://jira.mongodb.org/browse/EVG-15682

Remove the `DISABLE_COVERAGE` flag. The only thing that this does is when you run `make test-<package>`, it adds a summary line at the end of the go test output to include the percentage of lines covered that looks like this:
```
coverage:  <N>% of statements
```
I don't think this is particularly useful - instead, it's more useful is to run `make coverage-<package>` or `make html-coverage-<package>`, which produces more detailed information about code coverage rather than a single aggregate coverage number. Those coverage targets do not depend on `DISABLE_COVERAGE`.