### PR TITLE
EVG-15932: Fix premature flushing for Collector service in poplar

### DIFF
--- a/rpc/internal/collector.service.go
+++ b/rpc/internal/collector.service.go
@@ -249,7 +249,7 @@ func (sg *streamGroup) closeStream(id string) error {
 		return nil
 	}
 	stream.closed = true
-	if stream.buffer.Len() == 0 {
+	if !stream.inHeap {
 		delete(sg.streams, id)
 	}
 

--- a/rpc/internal/collector.service_test.go
+++ b/rpc/internal/collector.service_test.go
@@ -361,7 +361,7 @@ func TestStreamEvent(t *testing.T) {
 
 		// Add one event to the first stream and close it. This will
 		// check that streams closed early are not flushed until all
-		// other streams have recieved at least one item.
+		// other streams have received at least one item.
 		event.Time = &timestamp.Timestamp{Seconds: time.Now().Add(24 * time.Hour).Unix()}
 		require.NoError(t, streams[0].Send(&event))
 		_, err := streams[0].CloseAndRecv()


### PR DESCRIPTION
JIRA: https://jira.mongodb.org/browse/EVG-15932

This simple fix just checks that a stream does not have an item in the stream group's heap, rather than that the stream's buffer is empty, before removing it from the stream group. This prevents premature flushing because we use the number of streams currently present in the stream group to determine when it is safe to flush. If a stream has an item in the stream group's heap and it is removed, it should be marked for removal but not actually removed until all of its items have been written to the collector (i.e. there is nothing more to add to the heap from that stream).